### PR TITLE
Bugfix: AI cant build a dome if enemy hasn't air units

### DIFF
--- a/REDALERT/HOUSE.CPP
+++ b/REDALERT/HOUSE.CPP
@@ -5787,6 +5787,20 @@ int HouseClass::AI_Building(void)
 			}
 		}
 
+		
+		/*
+		**	Build a Dome.
+		*/
+		if (BQuantity[STRUCT_RADAR] == 0) {
+			b = &BuildingTypeClass::As_Reference(STRUCT_RADAR);
+			if (Can_Build(b, ActLike) && (b->Cost_Of() < money || hasincome)) {
+				choiceptr = BuildChoice.Alloc();
+				if (choiceptr != NULL) {
+					*choiceptr = BuildChoiceClass(URGENCY_MEDIUM, b->Type);
+				}
+			}
+		}
+		
 		/*
 		**	Build some air defense.
 		*/


### PR DESCRIPTION
Bugfix:
AI only builds a Dome if enemy has air units and it wants Air Defence,
Now it can build a dome and unlock the rest of the units and buildings without waiting for Enemy Air stuff.